### PR TITLE
EVE-1141:Add support for default value in prop in `doStepIf`

### DIFF
--- a/eve/util/step_factory.py
+++ b/eve/util/step_factory.py
@@ -102,7 +102,7 @@ def replace_with_interpolate(obj, key=None):
 
 
 class BooleanInterpolate(Interpolate):
-    INTERPOLATION_REGEX = re.compile(r'^%\((prop|secret):[\w._-]*\)s$')
+    INTERPOLATION_REGEX = re.compile(r'^%\((prop|secret):[\w._-]*(:-.*)?\)s$')
 
     def __init__(self, fmtstring):
         if not BooleanInterpolate.INTERPOLATION_REGEX.match(fmtstring):

--- a/tests/system/test_yaml_syntax.py
+++ b/tests/system/test_yaml_syntax.py
@@ -163,6 +163,20 @@ class TestYamlSyntax(unittest.TestCase):
                     },
                 )
 
+        # Test with property not set and default value
+        for truthy, values in example_values.items():
+            for value in values:
+                steps = [
+                    run_step(doStepIf='%(prop:someprop:-{})s'.format(value)),
+                ]
+
+                self._check_build_and_last_step(
+                    steps,
+                    last_step_attrs={
+                        'result': 'success' if truthy else 'skipped'
+                    },
+                )
+
         # Also works for hiding steps
         for truthy in example_values:
             steps = [
@@ -192,6 +206,16 @@ class TestYamlSyntax(unittest.TestCase):
         last_step = self._check_build_and_last_step(
             [set_property('someprop', 'not-a-bool'),
              run_step(doStepIf='%(prop:someprop)s')],
+            build_result='exception',
+            last_step_attrs={'result': 'exception'},
+        )
+
+        self.assertIn('Invalid value to cast as boolean: not-a-bool',
+                      last_step.rawlog('err_text'))
+
+        # Check unsupported default value
+        last_step = self._check_build_and_last_step(
+            [run_step(doStepIf='%(prop:someprop:-not-a-bool)s')],
             build_result='exception',
             last_step_attrs={'result': 'exception'},
         )


### PR DESCRIPTION
`doStepIf` argument from step support property but it does not allow to
provide a default value for this property (`%(prop:my_prop:-false)`),
this commit add this support.